### PR TITLE
nixBuildStep: pass argstr compiler to nix-build

### DIFF
--- a/haskell-ci.dhall
+++ b/haskell-ci.dhall
@@ -446,7 +446,12 @@ let installCachixStep =
               : Optional (Prelude.Map.Type Text Text)
           }
 
-let nixBuildStep = BuildStep.Name { name = "Build with Nix", run = "nix-build" }
+let nixBuildStep =
+      BuildStep.Name
+        { name = "Build with Nix"
+        , run =
+            "nix-build --argstr compiler \$(echo ghc\${{ matrix.ghc }} | tr -d '.')"
+        }
 
 let withNix =
       λ(steps : Steps.Type) →


### PR DESCRIPTION
this is rewritten trfrom e.g. 9.6.3 to ghc963

Use the following `default.nix` template
```nix
{ pkgs ? import <nixpkgs> {}
, compiler ? null
}:
let
  packageSet =
    if compiler == null
    then pkgs.haskellPackages
    else pkgs.haskell.packages.${compiler};
in ...
```